### PR TITLE
Get protocol from base in api.json for delete from url

### DIFF
--- a/lib/cs.rb
+++ b/lib/cs.rb
@@ -235,7 +235,10 @@ namespace :cs do
     desc "DELETE request by url"
     task :url, [:url] do |t, args|
       url = args[:url]
-      url = url.gsub(/http:/, 'https:') # always https
+
+      protocol = URI.parse( JSON.parse( IO.read('api.json') )["base"] ).scheme
+
+      url = url.gsub(/https?:/, "#{protocol}:") if protocol !~ /url/
       run command(base_command, 'DELETE', { url: url })
     end
 


### PR DESCRIPTION
Assuming https works for DTS but is not wise in general. Instead grab the protocol that's being used for api requests from the `api.json` file and use that (this is needed because cspace api returns urls without https for domains that are using ssl -- I distantly seem to recall).
